### PR TITLE
Update Frameworks, Fix customer font color causing Null object instance

### DIFF
--- a/TestProject/TestProject.csproj
+++ b/TestProject/TestProject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net40;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
     <AssemblyName>TestProject</AssemblyName>

--- a/WpfColorFontDialog/AvailableColors.cs
+++ b/WpfColorFontDialog/AvailableColors.cs
@@ -2,10 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Windows.Media;
+using System.Linq;
 
 namespace WpfColorFontDialog
 {
-	internal class AvailableColors : List<FontColor>
+    internal class AvailableColors : List<FontColor>
 	{
 		public AvailableColors()
 		{
@@ -38,6 +39,16 @@ namespace WpfColorFontDialog
 				}
 				found = brush;
 				break;
+			}
+
+			if (found == null)
+			{
+                found = this.FirstOrDefault(c => Color.AreClose(c.Brush.Color, b.Color));
+			}
+
+			if (found == null)
+			{
+				found = new FontColor("Current", b);
 			}
 			return found;
 		}

--- a/WpfColorFontDialog/WpfColorFontDialog.csproj
+++ b/WpfColorFontDialog/WpfColorFontDialog.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
     <AssemblyName>WpfColorFontDialog</AssemblyName>
     <RootNamespace>WpfColorFontDialog</RootNamespace>
     <Copyright>Copyright ©  2015</Copyright>
-    <Version>1.0.8.0</Version>
+    <Version>1.0.8.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>Added .NET Core 3.1 support.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added .Net 6.0 support.</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/sskodje/WpfColorFont/</RepositoryUrl>
     <PackageProjectUrl>https://github.com/sskodje/WpfColorFont/</PackageProjectUrl>
     <Description>A wpf color and font picker.</Description>


### PR DESCRIPTION
Fix to exception upon showing the dialog when a custom color is set in the FontInfo class value set in the Font property.